### PR TITLE
Indentation/whitespace cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.css]
+indent_style = space
+indent_size = 2
+
+[*.html]
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/gyronorm.js
+++ b/gyronorm.js
@@ -79,12 +79,12 @@
   var GyroNorm = function(options) {}
 
   /* Constants */
-  GyroNorm.prototype.GAME                             = 'game';
-  GyroNorm.prototype.WORLD                            = 'world';
-  GyroNorm.prototype.DEVICE_ORIENTATION               = 'deviceorientation';
-  GyroNorm.prototype.ACCELERATION                     = 'acceleration';
-  GyroNorm.prototype.ACCELERATION_INCLUDING_GRAVITY   = 'accelerationinludinggravity';
-  GyroNorm.prototype.ROTATION_RATE                    = 'rotationrate';
+  GyroNorm.GAME                             = GAME;
+  GyroNorm.WORLD                            = WORLD;
+  GyroNorm.DEVICE_ORIENTATION               = DEVICE_ORIENTATION;
+  GyroNorm.ACCELERATION                     = ACCELERATION;
+  GyroNorm.ACCELERATION_INCLUDING_GRAVITY   = ACCELARATION_INCLUDING_GRAVITY;
+  GyroNorm.ROTATION_RATE                    = ROTATION_RATE;
 
   /*
   *
@@ -210,7 +210,7 @@
   *
   */
   GyroNorm.prototype.setHeadDirection = function() {
-    if (_screenAdjusted || _orientationBase === this.WORLD) {
+    if (_screenAdjusted || _orientationBase === WORLD) {
       return false;
     }
 
@@ -250,19 +250,19 @@
   GyroNorm.prototype.isAvailable = function(_eventType) {
 
     switch (_eventType) {
-      case this.DEVICE_ORIENTATION:
+      case DEVICE_ORIENTATION:
         return (_do.isAvailable(_do.ALPHA) && _do.isAvailable(_do.BETA) && _do.isAvailable(_do.GAMMA));
         break;
 
-      case this.ACCELERATION:
+      case ACCELERATION:
         return (_dm.isAvailable(_dm.ACCELERATION_X) && _dm.isAvailable(_dm.ACCELERATION_Y) && _dm.isAvailable(_dm.ACCELERATION_Z));
         break;
 
-      case this.ACCELERATION_INCLUDING_GRAVITY:
+      case ACCELERATION_INCLUDING_GRAVITY:
         return (_dm.isAvailable(_dm.ACCELERATION_INCLUDING_GRAVITY_X) && _dm.isAvailable(_dm.ACCELERATION_INCLUDING_GRAVITY_Y) && _dm.isAvailable(_dm.ACCELERATION_INCLUDING_GRAVITY_Z));
         break;
 
-      case this.ROTATION_RATE:
+      case ROTATION_RATE:
         return (_dm.isAvailable(_dm.ROTATION_RATE_ALPHA) && _dm.isAvailable(_dm.ROTATION_RATE_BETA) && _dm.isAvailable(_dm.ROTATION_RATE_GAMMA));
         break;
 
@@ -271,7 +271,7 @@
           deviceOrientationAvailable: (_do.isAvailable(_do.ALPHA) && _do.isAvailable(_do.BETA) && _do.isAvailable(_do.GAMMA)),
           accelerationAvailable: (_dm.isAvailable(_dm.ACCELERATION_X) && _dm.isAvailable(_dm.ACCELERATION_Y) && _dm.isAvailable(_dm.ACCELERATION_Z)),
           accelerationIncludingGravityAvailable: (_dm.isAvailable(_dm.ACCELERATION_INCLUDING_GRAVITY_X) && _dm.isAvailable(_dm.ACCELERATION_INCLUDING_GRAVITY_Y) && _dm.isAvailable(_dm.ACCELERATION_INCLUDING_GRAVITY_Z)),
-          rotationRateAvailable: (_dm.isAvailable(_dm.ROTATION_RATE_ALPHA) && _dm.isAvailable(_dm.ROTATION_RATE_BETA) && _dm.isAvailable(_dm.ROTATION_RATE_GAMMA))     
+          rotationRateAvailable: (_dm.isAvailable(_dm.ROTATION_RATE_ALPHA) && _dm.isAvailable(_dm.ROTATION_RATE_BETA) && _dm.isAvailable(_dm.ROTATION_RATE_GAMMA))
         }
         break;
     }


### PR DESCRIPTION
This PR replaces all tabs with 2-space indentation, which is common for most JS code.
An .editorconfig file has been added, so that IDEs/editors such as sublime, atom, webstorm etc. can automatically switch to the correct indentation for this project.
Constants that were defined but never used (GAME, WORLD, etc) are now used in the factory function to remove some duplication in the code.
The constants are also exported on the GyroNorm constructor function, so they can be used without needing a GyroNorm instance. eg

before
```
console.log(new GyroNorm().WORLD);
```

after
```
console.log(GyroNorm.WORLD);
```