### PR TITLE
Bugfix/simplify init promises

### DIFF
--- a/gyronorm.js
+++ b/gyronorm.js
@@ -109,37 +109,19 @@
     if (options && options.logger) _logger = options.logger;
     if (options && options.screenAdjusted) _screenAdjusted = options.screenAdjusted;
 
-    return new Promise(function(resolve, reject) {
-      var isDeviceOrientationReady = false;
-      var isDeviceMotionReady = false;
-
-      new FULLTILT.getDeviceOrientation({ 'type': _orientationBase }).then(function(controller) {
-        _do = controller;
-        isDeviceOrientationReady = true;
-
-        if (isDeviceOrientationReady && isDeviceMotionReady) {
-          _isReady = true;
-          resolve();
-        }
-      }).catch(function(err) {
-        reject(err);
-      });
-
-      new FULLTILT.getDeviceMotion().then(function(controller) {
-        isDeviceMotionReady = true;
-        _dm = controller;
-        // Set gravity coefficient
-        _gravityCoefficient = (_dm.getScreenAdjustedAccelerationIncludingGravity().z > 0) ? 1 : -1;
-
-        if (isDeviceOrientationReady && isDeviceMotionReady) {
-          _isReady = true;
-          resolve();
-        }
-      }).catch(function(err) {
-        reject(err);
-      });
+    var deviceOrientationPromise = new FULLTILT.getDeviceOrientation({ 'type': _orientationBase }).then(function(controller) {
+      _do = controller;
     });
 
+    var deviceMotionPromise = new FULLTILT.getDeviceMotion().then(function(controller) {
+      _dm = controller;
+      // Set gravity coefficient
+      _gravityCoefficient = (_dm.getScreenAdjustedAccelerationIncludingGravity().z > 0) ? 1 : -1;
+    });
+
+    return Promise.all([deviceOrientationPromise, deviceMotionPromise]).then(function() {
+      _isReady = true;
+    });
   }
 
   /*

--- a/gyronorm.js
+++ b/gyronorm.js
@@ -42,7 +42,7 @@
   /* OPTIONS */
   var _frequency          = 50;         // Frequency for the return data in milliseconds
   var _gravityNormalized  = true;       // Flag if to normalize gravity values
-  var _orientationBase    = 'game';     // Can be GyroNorm.GAME or GyroNorm.WORLD. GyroNorm.GAME returns orientation values with respect to the head direction of the device. GyroNorm.WORLD returns the orientation values with respect to the actual north direction of the world.
+  var _orientationBase    = GAME;       // Can be GyroNorm.GAME or GyroNorm.WORLD. GyroNorm.GAME returns orientation values with respect to the head direction of the device. GyroNorm.WORLD returns the orientation values with respect to the actual north direction of the world.
   var _decimalCount       = 2;          // Number of digits after the decimals point for the return values
   var _logger             = null;       // Function to callback on error. There is no default value. It can only be set by the user on gn.init()
   var _screenAdjusted     = false;      // If set to true it will return screen adjusted values. (e.g. On a horizontal orientation of a mobile device, the head would be one of the sides, instead of  the actual head of the device.)


### PR DESCRIPTION
This PR simplifies the ```init()``` function significantly by making use of ```Promise.all``` to resolve when both ```FULLTILT.getDeviceOrientation ``` and ```FULLTILT.getDeviceMotion``` have resolved and will then flag ```_isReady = true```.

This also fixes a bug that could cause the promise that was returned on [this](https://github.com/dorukeker/gyronorm.js/blob/master/gyronorm.js#L112) line to reject more than once in case of an error being thrown in the ```catch``` calls (A promise may never be resolved/rejected more than once).