### PR TITLE
Fix example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var GyroNorm = require('gyronorm').GyroNorm;
 #### ES6
 
 ```js
-import { GyroNorm } from 'gyronorm';
+import GyroNorm from 'gyronorm';
 ```
 
 


### PR DESCRIPTION
In the example code for ES6 imports it should use the default import instead of a named one. Named variable is undefined in this case.